### PR TITLE
compile bundle on native side if 'compileBundle()' is available on native side

### DIFF
--- a/packages/weex-vue-framework/index.js
+++ b/packages/weex-vue-framework/index.js
@@ -35,6 +35,7 @@ function init (cfg) {
   renderer.Element = cfg.Element;
   renderer.Comment = cfg.Comment;
   renderer.sendTasks = cfg.sendTasks;
+  renderer.compileBundle = cfg.compileBundle;
 }
 
 /**
@@ -119,7 +120,12 @@ function createInstance (
     // deprecated
     __weex_require_module__: weexInstanceVar.requireModule // eslint-disable-line
   }, timerAPIs);
-  callFunction(instanceVars, appCode);
+
+  if (!callFunctionNative(instanceVars, appCode)) {
+    // If failed to compile functionBody on native side,
+    // fallback to 'callFunction()'.
+    callFunction(instanceVars, appCode);
+  }
 
   // Send `createFinish` signal to native.
   renderer.sendTasks(instanceId + '', [{ module: 'dom', method: 'createFinish', args: [] }], -1);
@@ -402,6 +408,58 @@ function callFunction (globalObjects, body) {
 
   var result = new (Function.prototype.bind.apply( Function, [ null ].concat( globalKeys) ));
   return result.apply(void 0, globalValues)
+}
+
+/**
+ * Call a new function generated on the V8 native side.
+ *
+ * This function helps speed up bundle compiling. Normally, the V8
+ * engine needs to download, parse, and compile a bundle on every
+ * visit. If 'compileBundle()' is available on native side,
+ * the downloding, parsing, and compiling steps would be skipped.
+ * @param  {object} globalObjects
+ * @param  {string} body
+ * @return {boolean}
+ */
+function callFunctionNative (globalObjects, body) {
+  if (typeof renderer.compileBundle !== 'function') {
+    return false
+  }
+
+  var fn = void 0;
+  var isNativeCompileOk = false;
+  var script = '(function (';
+  var globalKeys = [];
+  var globalValues = [];
+  for (var key in globalObjects) {
+    globalKeys.push(key);
+    globalValues.push(globalObjects[key]);
+  }
+  for (var i = 0; i < globalKeys.length - 1; ++i) {
+    script += globalKeys[i];
+    script += ',';
+  }
+  script += globalKeys[globalKeys.length - 1];
+  script += ') {';
+  script += body;
+  script += '} )';
+
+  try {
+    var weex = globalObjects.weex || {};
+    var config = weex.config || {};
+    fn = renderer.compileBundle(script,
+                                config.bundleUrl,
+                                config.bundleDigest,
+                                config.codeCachePath);
+    if (fn && typeof fn === 'function') {
+      fn.apply(void 0, globalValues);
+      isNativeCompileOk = true;
+    }
+  } catch (e) {
+    console.error(e);
+  }
+
+  return isNativeCompileOk
 }
 
 /**


### PR DESCRIPTION
Normally, a bundle needs downloading, parsing, compiling, executing steps on every visit. V8 engine supports the feature of code cache and if we introduce this feature on native side, the downloading, parsing and compiling steps would be skipped. 