### PR TITLE
call C++ timer instead of WxTimerModule in weex-vue-framwork

### DIFF
--- a/src/platforms/weex/framework.js
+++ b/src/platforms/weex/framework.js
@@ -340,19 +340,45 @@ function getInstanceTimer (instanceId, moduleGetter) {
       const handler = function () {
         args[0](...args.slice(2))
       }
-      timer.setTimeout(handler, args[1])
+
+      var instance = instances[instanceId]
+      var timerId, callbackId
+      if (global.setTimeoutWeex && (typeof global.setTimeoutWeex === 'function')) {
+        callbackId = instance.document.taskCenter.normalize(handler)
+        timerId = global.setTimeoutWeex(instanceId, callbackId, args[1])
+        return timerId
+      } else {
+        timer.setTimeout(handler, args[1])
+      }
     },
     setInterval: (...args) => {
       const handler = function () {
         args[0](...args.slice(2))
       }
-      timer.setInterval(handler, args[1])
+
+      var instance = instances[instanceId]
+      var timerId, callbackId
+      if (global.setIntervalWeex && (typeof global.setIntervalWeex === 'function')) {
+        callbackId = instance.document.taskCenter.normalize(handler)
+        timerId = global.setIntervalWeex(instanceId, callbackId, args[1])
+        return timerId
+      } else {
+        timer.setInterval(handler, args[1])
+      }
     },
     clearTimeout: (n) => {
-      timer.clearTimeout(n)
+      if (global.clearTimeoutWeex && (typeof global.clearTimeoutWeex === 'function')) {
+        global.clearTimeoutWeex(n)
+      } else {
+        timer.clearTimeout(n)
+      }
     },
     clearInterval: (n) => {
-      timer.clearInterval(n)
+      if (global.clearIntervalWeex && (typeof global.clearIntervalWeex === 'function')) {
+        global.clearIntervalWeex(n)
+      } else {
+        timer.clearInterval(n)
+      }
     }
   }
   return timerAPIs


### PR DESCRIPTION
在.vue文件中调用settimeout等函数时，调用c++ timer而不是WxTimerModule